### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-
 permissions:
   contents: read
-
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:    
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Leffell-Space/live_data_analysis/security/code-scanning/2](https://github.com/Leffell-Space/live_data_analysis/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs basic CI tasks, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to complete the workflow tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional changes are required to the workflow steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
